### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           cat .env
            
       - name: Publish image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: registry.heroku.com/${{ secrets.HEROKU_APP_NAME }}/web
           username: _


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore